### PR TITLE
dts: RK805: Add missing regulator and supply definitions.

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3328-rock64.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3328-rock64.dts
@@ -144,6 +144,14 @@
 		vin-supply = <&vcc_io>;
 	};
 
+	vcc_sys: vsys-regulator {
+		compatible = "regulator-fixed";
+		regulator-name = "vcc_sys";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		regulator-always-on;
+	};
+
 	wireless-wlan {
 		compatible = "wlan-platdata";
 		rockchip,grf = <&grf>;
@@ -224,6 +232,13 @@
 		#gpio-cells = <2>;
 		#clock-cells = <1>;
 		clock-output-names = "xin32k", "rk805-clkout2";
+
+		vcc1-supply = <&vcc_sys>;
+		vcc2-supply = <&vcc_sys>;
+		vcc3-supply = <&vcc_sys>;
+		vcc4-supply = <&vcc_sys>;
+		vcc5-supply = <&vcc_io>;
+		vcc6-supply = <&vcc_io>;
 
 		rtc {
 			status = "disabled";


### PR DESCRIPTION
Add missing regulator for DC input 5V (vcc_sys), add regulator input definitions for RK805. The DC/DC buck converters 1-4 (supply 1-4) are fed by 5V directly, the LDOs (supply 5&6) are fed by the output of VCC_IO (buck converter 4)  for details check Rock64 schematics.