### PR TITLE
dts: fix mmc node property ordering, missing regulators and cd-gpios

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3328-rock64.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3328-rock64.dts
@@ -145,20 +145,22 @@
 };
 
 &emmc {
-	max-frequency = <200000000>;
+	bus-width = <8>;
+	cap-mmc-highspeed;
 	clocks = <&cru HCLK_EMMC>, <&cru SCLK_EMMC>,
 		 <&cru SCLK_EMMC_DRV>, <&cru SCLK_EMMC_SAMPLE>;
 	clock-names = "biu", "ciu", "ciu-drv", "ciu-sample";
-	bus-width = <8>;
-	cap-mmc-highspeed;
-	mmc-hs200-1_8v;
-	supports-emmc;
 	disable-wp;
+	max-frequency = <200000000>;
+	mmc-hs200-1_8v;
 	non-removable;
 	num-slots = <1>;
 	pinctrl-names = "default";
 	pinctrl-0 = <&emmc_clk &emmc_cmd &emmc_bus8>;
 	status = "okay";
+	supports-emmc;
+	vmmc-supply = <&vcc_io>;
+	vqmmc-supply = <&vcc_18emmc>;
 };
 
 &gmac2io {
@@ -398,6 +400,7 @@
 	bus-width = <4>;
 	cap-mmc-highspeed;
 	cap-sd-highspeed;
+	cd-gpios = <&gpio1 RK_PA5 GPIO_ACTIVE_LOW>;
 	disable-wp;
 	max-frequency = <150000000>;
 	num-slots = <1>;
@@ -406,6 +409,7 @@
 	supports-sd;
 	status = "okay";
 	vmmc-supply = <&vcc_sd>;
+	vqmmc-supply = <&vcc_sd>;
 };
 
 &spdif {


### PR DESCRIPTION
Some clean-up fixes for mmc nodes, added missing regulator definitions and card detect for sdcard.