### PR TITLE
Missing rockchip,grf value

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3328.dtsi
+++ b/arch/arm64/boot/dts/rockchip/rk3328.dtsi
@@ -934,6 +934,7 @@
 		compatible = "rockchip,rk3328-vop";
 		reg = <0x0 0xff370000 0x0 0x3efc>;
 		reg-names = "regs", "gamma_lut";
+		rockchip,grf = <&grf>;
 		interrupts = <GIC_SPI 32 IRQ_TYPE_LEVEL_HIGH>;
 		clocks = <&cru ACLK_VOP>, <&cru DCLK_LCDC>, <&cru HCLK_VOP>;
 		clock-names = "aclk_vop", "dclk_vop", "hclk_vop";


### PR DESCRIPTION
This avoids a boot msg complaining that rockchip-vop ff370000.vop is missing rockchip,grf property