### PR TITLE
Remove duplicate vcc_sys - consider replacing with vcc_io

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3328-rock64.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3328-rock64.dts
@@ -134,15 +134,6 @@
 		vin-supply = <&vcc_sys>;
 	};
 
-	vcc_sys: vcc-sys {
-		compatible = "regulator-fixed";
-		regulator-name = "vcc_sys";
-		regulator-always-on;
-		regulator-boot-on;
-		regulator-min-microvolt = <5000000>;
-		regulator-max-microvolt = <5000000>;
-	};
-
 	ir-receiver {
 		compatible = "gpio-ir-receiver";
 		pinctrl-0 = <&ir_int>;


### PR DESCRIPTION
There are two branch entries for vcc_sys: vcc-sys. This patch removes one.

Additional detail... This duplicate doesn't exist in the DTS in the parent rockchip repo. Perhaps the duplicate was added by mistake and was supposed to be vcc_io? There's currently a warning/message on boot regarding vcc_sd not being able to find a regulator. This is coming from the vin-supply lookup for vcc_sd: sdmmc-regulator and that's pointed to vcc_io, which doesn't actually have a branch at this level in the DTS. While this patch removes the duplicate entry, I think a better fix would be replacing the entry with the missing vcc_io entry. I do not know the correct structure for that, however, so I didn't want to submit a patch with any settings that I had to guess. I'm sure you will know the right param structure and settings for vcc_io, so feel free to modify the patch if you agree with my analysis and replace with the vcc_io structure instead of removing the duplicate vcc_sys.