### PR TITLE
RK3328 sdmmc0 drive level change to 8mA

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3328.dtsi
+++ b/arch/arm64/boot/dts/rockchip/rk3328.dtsi
@@ -2053,35 +2053,35 @@
 		sdmmc0 {
 			sdmmc0_clk: sdmmc0-clk {
 				rockchip,pins =
-					<1 RK_PA6 RK_FUNC_1 &pcfg_pull_none_4ma>;
+					<1 RK_PA6 RK_FUNC_1 &pcfg_pull_none_8ma>;
 			};
 
 			sdmmc0_cmd: sdmmc0-cmd {
 				rockchip,pins =
-					<1 RK_PA4 RK_FUNC_1 &pcfg_pull_up_4ma>;
+					<1 RK_PA4 RK_FUNC_1 &pcfg_pull_up_8ma>;
 			};
 
 			sdmmc0_dectn: sdmmc0-dectn {
 				rockchip,pins =
-					<1 RK_PA5 RK_FUNC_1 &pcfg_pull_up_4ma>;
+					<1 RK_PA5 RK_FUNC_1 &pcfg_pull_up_8ma>;
 			};
 
 			sdmmc0_wrprt: sdmmc0-wrprt {
 				rockchip,pins =
-					<1 RK_PA7 RK_FUNC_1 &pcfg_pull_up_4ma>;
+					<1 RK_PA7 RK_FUNC_1 &pcfg_pull_up_8ma>;
 			};
 
 			sdmmc0_bus1: sdmmc0-bus1 {
 				rockchip,pins =
-					<1 RK_PA0 RK_FUNC_1 &pcfg_pull_up_4ma>;
+					<1 RK_PA0 RK_FUNC_1 &pcfg_pull_up_8ma>;
 			};
 
 			sdmmc0_bus4: sdmmc0-bus4 {
 				rockchip,pins =
-					<1 RK_PA0 RK_FUNC_1 &pcfg_pull_up_4ma>,
-					<1 RK_PA1 RK_FUNC_1 &pcfg_pull_up_4ma>,
-					<1 RK_PA2 RK_FUNC_1 &pcfg_pull_up_4ma>,
-					<1 RK_PA3 RK_FUNC_1 &pcfg_pull_up_4ma>;
+					<1 RK_PA0 RK_FUNC_1 &pcfg_pull_up_8ma>,
+					<1 RK_PA1 RK_FUNC_1 &pcfg_pull_up_8ma>,
+					<1 RK_PA2 RK_FUNC_1 &pcfg_pull_up_8ma>,
+					<1 RK_PA3 RK_FUNC_1 &pcfg_pull_up_8ma>;
 			};
 
 			sdmmc0_gpio: sdmmc0-gpio {


### PR DESCRIPTION
SD Instability has been a commonly reported issue on RK3328 boards, the Rockchip default drive level of 4mA is unable to reliably drive any significant capacitive load (even within SD card specification) at 50MHz high speed, especially with 3.3V signalling.  Further testing may indicate a need for 12mA, but for now this patch has been shown to resolve SD boot and stability issues on several boards, including Rock64 and a Renegade.  The issue spanning multiple boards is why I didn't simply override the settings in the board specific DTS.

It may also be important to note the ASUS Tinker Board (RK3288) uses 8mA drive levels.  This may be worth evaluating for RK3399 as well.