### PR TITLE
Enable SDIO and add missing WIFI nodes

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3399-rockpro64.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3399-rockpro64.dts
@@ -105,6 +105,17 @@
 		regulator-always-on;
 	};
 
+	vcc1v8_wifi: vcc1v8-wifi {
+		compatible = "regulator-fixed";
+		enable-active-high;
+		gpios = <&gpio0 RK_PB5 GPIO_ACTIVE_HIGH>; 
+		pinctrl-names = "default";
+		pinctrl-0 = <&wifi_pwr>;
+		regulator-name = "vcc1v8_wifi";
+		regulator-boot-on;
+		vin-supply = <&vcc_1v8>;
+	};
+
 	vcc_sys: vcc-sys {
 		compatible = "regulator-fixed";
 		regulator-name = "vcc_sys";
@@ -194,7 +205,7 @@
 	wireless-wlan {
 		compatible = "wlan-platdata";
 		rockchip,grf = <&grf>;
-		wifi_chip_type = "ap6354";
+		wifi_chip_type = "ap6359sa";
 		sdio_vref = <1800>;
 		WIFI,host_wake_irq = <&gpio0 3 GPIO_ACTIVE_HIGH>;
 		status = "okay";
@@ -332,7 +343,7 @@
 	pinctrl-names = "default";
 	pinctrl-0 = <&sdio0_bus4 &sdio0_cmd &sdio0_clk>;
 	sd-uhs-sdr104;
-	status = "disabled";
+	status = "okay";
 };
 
 &emmc_phy {
@@ -910,6 +921,12 @@
 		wifi_enable_h: wifi-enable-h {
 			rockchip,pins =
 				<0 10 RK_FUNC_GPIO &pcfg_pull_none>;
+		};
+	};
+	
+	wireless-wlan {
+		wifi_pwr: wifi-pwr {
+			rockchip,pins = <0 RK_PB5 RK_FUNC_GPIO &pcfg_pull_none>;
 		};
 	};
 


### PR DESCRIPTION
These edits will enable the wifi combo chip on the rockpro for the 2.0 AND 2.1 boards. There is still firmware required for it to work that RFKILL will need to load, but that's outside the scope of this PR.

NOTE: There is a possibility this change will cause a conflict with the PCIE being enabled. I have not disabled it in this PR, so if you encounter instability then I recommend disabling pcie0 and pcie_phy.