### PR TITLE
[PATCH] drm: workaround for crash when trying to open render node

### DIFF
--- a/drivers/gpu/drm/drm_ioctl.c
+++ b/drivers/gpu/drm/drm_ioctl.c
@@ -57,6 +57,9 @@ static int drm_getunique(struct drm_device *dev, void *data,
 	struct drm_unique *u = data;
 	struct drm_master *master = file_priv->master;
 
+	if (!master)
+		return -EINVAL;
+
 	if (u->unique_len >= master->unique_len) {
 		if (copy_to_user(u->unique, master->unique, master->unique_len))
 			return -EFAULT;


### PR DESCRIPTION
Apply drm_getunique patch to fix Kodi GBM/KMS/DRM crash on start.
Ref: https://raw.githubusercontent.com/armbian/build/master/patch/kernel/rk3399-default/50-fix_drm.patch