### PR TITLE
dts: rock64: allow SD card voltage switching (UHS-I)

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3328-rock64.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3328-rock64.dts
@@ -90,13 +90,23 @@
 
 	vcc_sd: sdmmc-regulator {
 		compatible = "regulator-fixed";
-		gpio = <&gpio0 30 GPIO_ACTIVE_LOW>;
-		pinctrl-names = "default";
-		pinctrl-0 = <&sdmmc0m1_gpio>;
 		regulator-name = "vcc_sd";
 		regulator-min-microvolt = <3300000>;
 		regulator-max-microvolt = <3300000>;
+		regulator-always-on;
 		vin-supply = <&vcc_io>;
+	};
+
+	vccq_sd: sdmmc-regulator-vccq {
+		compatible = "regulator-gpio";
+		regulator-name = "vccq_sd";
+		regulator-min-microvolt = <1800000>;
+		regulator-max-microvolt = <3300000>;
+		pinctrl-names = "default";
+		pinctrl-0 = <&sdmmc0m1_gpio>;
+		gpios = <&gpio0 30 GPIO_ACTIVE_LOW>;
+		states = <3300000 0
+			  1800000 1>;
 	};
 
 	vcc_host_5v: vcc-host-5v-regulator {
@@ -520,7 +530,7 @@
 
 	vccio1-supply = <&vcc_io>;
 	vccio2-supply = <&vcc18_emmc>;
-	vccio3-supply = <&vcc_io>;
+	vccio3-supply = <&vccq_sd>;
 	vccio4-supply = <&vdd_18>;
 	vccio5-supply = <&vcc_io>;
 	vccio6-supply = <&vcc_io>;
@@ -693,8 +703,9 @@
 	pinctrl-names = "default";
 	pinctrl-0 = <&sdmmc0_clk &sdmmc0_cmd &sdmmc0_dectn &sdmmc0_bus4>;
 	vmmc-supply = <&vcc_sd>;
-	vqmmc-supply = <&vcc_sd>;
+	vqmmc-supply = <&vccq_sd>;
 	supports-sd;
+	sd-uhs-sdr104;
 	status = "okay";
 };
 


### PR DESCRIPTION
Allow rock64 version 3 to use UHS-I with 1.8V (SDR104 with 150MHz clock limit).
This DTS  patch is probably incompatible with rock64 version 2.
[Check pine64 forum too](https://forum.pine64.org/showthread.php?tid=7641&pid=48561#pid48561)

```
# ### card SanDisk Ultra UHS-I "speed up 80MB/s" on local root filesystem ext4
# iozone -e -I -a -s 100M -r 4k -r 1024k -i 0 -i 1 -i 2
<snip>
                                                              random    random     bkwd    record    stride                                    
              kB  reclen    write  rewrite    read    reread    read     write     read   rewrite      read   fwrite frewrite    fread  freread
          102400       4     5137     5423    12240    12239     9424     5013                                                          
          102400    1024    14676    22077    67482    67564    67270    31640                                                          
```